### PR TITLE
RSpec 3.0.x syntax changes

### DIFF
--- a/spec/sandal/claims_spec.rb
+++ b/spec/sandal/claims_spec.rb
@@ -7,38 +7,38 @@ describe Sandal::Claims do
     it 'calls #validate_aud when valid audiences are provided' do
       claims = { 'aud' => 'example.org' }.extend(Sandal::Claims)
       valid_aud = %w(example.org)
-      claims.should_receive(:validate_aud).with(valid_aud)
+      expect(claims).to receive(:validate_aud).with(valid_aud)
       claims.validate_claims(valid_aud: valid_aud)
     end
 
     it 'calls #validate_exp by default' do
       claims = {}.extend(Sandal::Claims)
-      claims.should_receive(:validate_exp)
+      expect(claims).to receive(:validate_exp)
       claims.validate_claims
     end
 
     it 'does not call #validate_exp when the :ignore_exp option is set' do
       claims = {}.extend(Sandal::Claims)
-      claims.should_not_receive(:validate_exp)
+      expect(claims).not_to receive(:validate_exp)
       claims.validate_claims(ignore_exp: true)
     end
 
     it 'calls #validate_iss when valid issuers are provided' do
       claims = { 'iss' => 'example.org' }.extend(Sandal::Claims)
       valid_iss = %w(example.org)
-      claims.should_receive(:validate_iss).with(valid_iss)
+      expect(claims).to receive(:validate_iss).with(valid_iss)
       claims.validate_claims(valid_iss: valid_iss)
     end
 
     it 'calls #validate_nbf by default' do
       claims = {}.extend(Sandal::Claims)
-      claims.should_receive(:validate_nbf)
+      expect(claims).to receive(:validate_nbf)
       claims.validate_claims
     end
 
     it 'does not call #validate_nbf when the :ignore_nbf option is set' do
       claims = {}.extend(Sandal::Claims)
-      claims.should_not_receive(:validate_nbf)
+      expect(claims).not_to receive(:validate_nbf)
       claims.validate_claims(ignore_nbf: true)
     end
 

--- a/spec/sandal/enc/a128cbc_hs256_spec.rb
+++ b/spec/sandal/enc/a128cbc_hs256_spec.rb
@@ -9,7 +9,7 @@ describe Sandal::Enc::A128CBC_HS256 do
   context "#name" do
     it "is 'A128CBC-HS256'" do
       enc = Sandal::Enc::A128CBC_HS256.new(Sandal::Enc::Alg::Direct.new("a cmk"))
-      enc.name.should == "A128CBC-HS256"
+      expect(enc.name).to eq("A128CBC-HS256")
     end
   end
 
@@ -17,7 +17,7 @@ describe Sandal::Enc::A128CBC_HS256 do
     it "can decrypt the example token from JWE draft-11 appendix 2", :jruby_incompatible do
       token="eyJhbGciOiJSU0ExXzUiLCJlbmMiOiJBMTI4Q0JDLUhTMjU2In0.UGhIOguC7IuEvf_NPVaXsGMoLOmwvc1GyqlIKOK1nN94nHPoltGRhWhw7Zx0-kFm1NJn8LE9XShH59_i8J0PH5ZZyNfGy2xGdULU7sHNF6Gp2vPLgNZ__deLKxGHZ7PcHALUzoOegEI-8E66jX2E4zyJKx-YxzZIItRzC5hlRirb6Y5Cl_p-ko3YvkkysZIFNPccxRU7qve1WYPxqbb2Yw8kZqa2rMWI5ng8OtvzlV7elprCbuPhcCdZ6XDP0_F8rkXds2vE4X-ncOIM8hAYHHi29NX0mcKiRaD0-D-ljQTP-cFPgwCp6X-nZZd9OHBv-B3oWh2TbqmScqXMR4gp_A.AxY8DCtDaGlsbGljb3RoZQ.KDlTtXchhZTGufMYmOYGS4HffxPSUrfmqCHXaI9wOGY.9hH0vgRfYgPnAHOd8stkvw"
       enc = Sandal::Enc::A128CBC_HS256.new(Sandal::Enc::Alg::RSA1_5.new(SampleKeys.jwe_draft11_appendix2_rsa))
-      enc.decrypt(token).should == "Live long and prosper."
+      expect(enc.decrypt(token)).to eq("Live long and prosper.")
     end
   end
 

--- a/spec/sandal/enc/a128gcm_spec.rb
+++ b/spec/sandal/enc/a128gcm_spec.rb
@@ -11,7 +11,7 @@ describe Sandal::Enc::A128GCM do
   context "#name" do
     it "is 'A128GCM'" do
       enc = Sandal::Enc::A128GCM.new(Sandal::Enc::Alg::Direct.new("a cmk"))
-      enc.name.should == "A128GCM"
+      expect(enc.name).to eq("A128GCM")
     end
   end
 

--- a/spec/sandal/enc/a256cbc_hs512_spec.rb
+++ b/spec/sandal/enc/a256cbc_hs512_spec.rb
@@ -11,7 +11,7 @@ describe Sandal::Enc::A256CBC_HS512 do
   context "#name" do
     it "is 'A256CBC-HS512'" do
       enc = Sandal::Enc::A256CBC_HS512.new(Sandal::Enc::Alg::Direct.new("a cmk"))
-      enc.name.should == "A256CBC-HS512"
+      expect(enc.name).to eq("A256CBC-HS512")
     end
   end
 

--- a/spec/sandal/enc/a256gcm_spec.rb
+++ b/spec/sandal/enc/a256gcm_spec.rb
@@ -12,7 +12,7 @@ describe Sandal::Enc::A256GCM do
 
     it "is 'A256GCM'" do
       enc = Sandal::Enc::A256GCM.new(Sandal::Enc::Alg::Direct.new("a cmk"))
-      enc.name.should == "A256GCM"
+      expect(enc.name).to eq("A256GCM")
     end
 
   end
@@ -21,7 +21,7 @@ describe Sandal::Enc::A256GCM do
     it "can decrypt the example token from JWE draft-11 appendix 1", :jruby_incompatible do
       token = "eyJhbGciOiJSU0EtT0FFUCIsImVuYyI6IkEyNTZHQ00ifQ.OKOawDo13gRp2ojaHV7LFpZcgV7T6DVZKTyKOMTYUmKoTCVJRgckCL9kiMT03JGeipsEdY3mx_etLbbWSrFr05kLzcSr4qKAq7YN7e9jwQRb23nfa6c9d-StnImGyFDbSv04uVuxIp5Zms1gNxKKK2Da14B8S4rzVRltdYwam_lDp5XnZAYpQdb76FdIKLaVmqgfwX7XWRxv2322i-vDxRfqNzo_tETKzpVLzfiwQyeyPGLBIO56YJ7eObdv0je81860ppamavo35UgoRdbYaBcoh9QcfylQr66oc6vFWXRcZ_ZT2LawVCWTIy3brGPi6UklfCpIMfIjf7iGdXKHzg.48V1_ALb6US04U3b.5eym8TW_c8SuK0ltJ3rpYIzOeDQz7TALvtu6UG9oMo4vpzs9tX_EFShS8iB7j6jiSdiwkIr3ajwQzaBtQD_A.XFBoMYUZodetZdvTiFvSkQ"
       enc = Sandal::Enc::A256GCM.new(Sandal::Enc::Alg::RSA_OAEP.new(SampleKeys.jwe_draft11_appendix1_rsa))
-      enc.decrypt(token).should == "The true sign of intelligence is not knowledge but imagination."
+      expect(enc.decrypt(token)).to eq("The true sign of intelligence is not knowledge but imagination.")
     end
   end
 

--- a/spec/sandal/enc/alg/direct_spec.rb
+++ b/spec/sandal/enc/alg/direct_spec.rb
@@ -6,7 +6,7 @@ describe Sandal::Enc::Alg::Direct do
   context "#name" do
     it "is 'dir'" do
       alg = Sandal::Enc::Alg::Direct.new("some key")
-      alg.name.should == "dir"
+      expect(alg.name).to eq("dir")
     end
   end
 
@@ -14,14 +14,14 @@ describe Sandal::Enc::Alg::Direct do
     it "returns the pre-shared key" do
       key = "the pre-shared key"
       alg = Sandal::Enc::Alg::Direct.new(key)
-      alg.preshared_key.should == key
+      expect(alg.preshared_key).to eq(key)
     end
   end
 
   context "#encrypt_key" do
     it "returns an empty string" do
       alg = Sandal::Enc::Alg::Direct.new("the real key")
-      alg.encrypt_key("any value").should == ""
+      expect(alg.encrypt_key("any value")).to eq("")
     end
   end
 
@@ -30,13 +30,13 @@ describe Sandal::Enc::Alg::Direct do
     it "returns the pre-shared content key when the value to decrypt is nil" do
       key = "a pre-shared key"
       alg = Sandal::Enc::Alg::Direct.new(key)
-      alg.decrypt_key(nil).should == key
+      expect(alg.decrypt_key(nil)).to eq(key)
     end
 
     it "returns the pre-shared content key when the value to decrypt is empty" do
       key = "my pre-shared key"
       alg = Sandal::Enc::Alg::Direct.new(key)
-      alg.decrypt_key("").should == key
+      expect(alg.decrypt_key("")).to eq(key)
     end
 
     it "raises an InvalidTokenError if the value to decrypt is not nil or empty" do

--- a/spec/sandal/enc/alg/rsa_spec.rb
+++ b/spec/sandal/enc/alg/rsa_spec.rb
@@ -8,7 +8,7 @@ shared_examples "encryption and decryption" do |enc_class|
     encrypter = enc_class.new(key.public_key)
     decrypter = enc_class.new(key)
     key = "an encryption key"
-    decrypter.decrypt_key(encrypter.encrypt_key(key)).should == key
+    expect(decrypter.decrypt_key(encrypter.encrypt_key(key))).to eq(key)
   end
 
   it "can use DER-encoded keys to encrypt and decrypt a content master key" do
@@ -16,7 +16,7 @@ shared_examples "encryption and decryption" do |enc_class|
     encrypter = enc_class.new(key.public_key.to_der)
     decrypter = enc_class.new(key.to_der)
     key = "an encryption key"
-    decrypter.decrypt_key(encrypter.encrypt_key(key)).should == key
+    expect(decrypter.decrypt_key(encrypter.encrypt_key(key))).to eq(key)
   end
 
   it "can use PEM-encoded keys to encrypt and decrypt a content master key" do
@@ -24,7 +24,7 @@ shared_examples "encryption and decryption" do |enc_class|
     encrypter = enc_class.new(key.public_key.to_pem)
     decrypter = enc_class.new(key.to_pem)
     key = "an encryption key"
-    decrypter.decrypt_key(encrypter.encrypt_key(key)).should == key
+    expect(decrypter.decrypt_key(encrypter.encrypt_key(key))).to eq(key)
   end
 
   context "#decrypt_key" do
@@ -61,7 +61,7 @@ describe Sandal::Enc::Alg::RSA1_5 do
   context "#name" do
     it "is 'RSA1_5'" do
       alg = Sandal::Enc::Alg::RSA1_5.new(OpenSSL::PKey::RSA.new(2048))
-      alg.name.should == "RSA1_5"
+      expect(alg.name).to eq("RSA1_5")
     end
   end
 
@@ -70,19 +70,19 @@ describe Sandal::Enc::Alg::RSA1_5 do
       key = [4, 211, 31, 197, 84, 157, 252, 254, 11, 100, 157, 250, 63, 170, 106, 206, 107, 124, 212, 45, 111, 107, 9, 219, 200, 177, 0, 240, 143, 156, 44, 207].pack("C*")
       encrypted_key = [80, 104, 72, 58, 11, 130, 236, 139, 132, 189, 255, 205, 61, 86, 151, 176, 99, 40, 44, 233, 176, 189, 205, 70, 202, 169, 72, 40, 226, 181, 156, 223, 120, 156, 115, 232, 150, 209, 145, 133, 104, 112, 237, 156, 116, 250, 65, 102, 212, 210, 103, 240, 177, 61, 93, 40, 71, 231, 223, 226, 240, 157, 15, 31, 150, 89, 200, 215, 198, 203, 108, 70, 117, 66, 212, 238, 193, 205, 23, 161, 169, 218, 243, 203, 128, 214, 127, 253, 215, 139, 43, 17, 135, 103, 179, 220, 28, 2, 212, 206, 131, 158, 128, 66, 62, 240, 78, 186, 141, 125, 132, 227, 60, 137, 43, 31, 152, 199, 54, 72, 34, 212, 115, 11, 152, 101, 70, 42, 219, 233, 142, 66, 151, 250, 126, 146, 141, 216, 190, 73, 50, 177, 146, 5, 52, 247, 28, 197, 21, 59, 170, 247, 181, 89, 131, 241, 169, 182, 246, 99, 15, 36, 102, 166, 182, 172, 197, 136, 230, 120, 60, 58, 219, 243, 149, 94, 222, 150, 154, 194, 110, 227, 225, 112, 39, 89, 233, 112, 207, 211, 241, 124, 174, 69, 221, 179, 107, 196, 225, 127, 167, 112, 226, 12, 242, 16, 24, 28, 120, 182, 244, 213, 244, 153, 194, 162, 69, 160, 244, 248, 63, 165, 141, 4, 207, 249, 193, 79, 131, 0, 169, 233, 127, 167, 101, 151, 125, 56, 112, 111, 248, 29, 232, 90, 29, 147, 110, 169, 146, 114, 165, 204, 71, 136, 41, 252].pack("C*")
       alg = Sandal::Enc::Alg::RSA1_5.new(SampleKeys.jwe_draft11_appendix2_rsa)
-      alg.decrypt_key(encrypted_key).should == key
+      expect(alg.decrypt_key(encrypted_key)).to eq(key)
     end
   end
 
 end
 
-describe Sandal::Enc::Alg::RSA_OAEP do 
-  include_examples "encryption and decryption", Sandal::Enc::Alg::RSA_OAEP 
+describe Sandal::Enc::Alg::RSA_OAEP do
+  include_examples "encryption and decryption", Sandal::Enc::Alg::RSA_OAEP
 
   context "#name" do
     it "is 'RSA-OAEP'" do
       alg = Sandal::Enc::Alg::RSA_OAEP.new(OpenSSL::PKey::RSA.new(2048))
-      alg.name.should == "RSA-OAEP"
+      expect(alg.name).to eq("RSA-OAEP")
     end
   end
 
@@ -91,7 +91,7 @@ describe Sandal::Enc::Alg::RSA_OAEP do
       key = [177, 161, 244, 128, 84, 143, 225, 115, 63, 180, 3, 255, 107, 154, 212, 246, 138, 7, 110, 91, 112, 46, 34, 105, 47, 130, 203, 46, 122, 234, 64, 252].pack("C*")
       encrypted_key = [56, 163, 154, 192, 58, 53, 222, 4, 105, 218, 136, 218, 29, 94, 203, 22, 150, 92, 129, 94, 211, 232, 53, 89, 41, 60, 138, 56, 196, 216, 82, 98, 168, 76, 37, 73, 70, 7, 36, 8, 191, 100, 136, 196, 244, 220, 145, 158, 138, 155, 4, 117, 141, 230, 199, 247, 173, 45, 182, 214, 74, 177, 107, 211, 153, 11, 205, 196, 171, 226, 162, 128, 171, 182, 13, 237, 239, 99, 193, 4, 91, 219, 121, 223, 107, 167, 61, 119, 228, 173, 156, 137, 134, 200, 80, 219, 74, 253, 56, 185, 91, 177, 34, 158, 89, 154, 205, 96, 55, 18, 138, 43, 96, 218, 215, 128, 124, 75, 138, 243, 85, 25, 109, 117, 140, 26, 155, 249, 67, 167, 149, 231, 100, 6, 41, 65, 214, 251, 232, 87, 72, 40, 182, 149, 154, 168, 31, 193, 126, 215, 89, 28, 111, 219, 125, 182, 139, 235, 195, 197, 23, 234, 55, 58, 63, 180, 68, 202, 206, 149, 75, 205, 248, 176, 67, 39, 178, 60, 98, 193, 32, 238, 122, 96, 158, 222, 57, 183, 111, 210, 55, 188, 215, 206, 180, 166, 150, 166, 106, 250, 55, 229, 72, 40, 69, 214, 216, 104, 23, 40, 135, 212, 28, 127, 41, 80, 175, 174, 168, 115, 171, 197, 89, 116, 92, 103, 246, 83, 216, 182, 176, 84, 37, 147, 35, 45, 219, 172, 99, 226, 233, 73, 37, 124, 42, 72, 49, 242, 35, 127, 184, 134, 117, 114, 135, 206].pack("C*")
       alg = Sandal::Enc::Alg::RSA_OAEP.new(SampleKeys.jwe_draft11_appendix1_rsa)
-      alg.decrypt_key(encrypted_key).should == key
+      expect(alg.decrypt_key(encrypted_key)).to eq(key)
     end
   end
 

--- a/spec/sandal/enc/shared_examples.rb
+++ b/spec/sandal/enc/shared_examples.rb
@@ -9,7 +9,7 @@ shared_examples "algorithm compatibility" do |enc_class|
     enc = enc_class.new(Sandal::Enc::Alg::Direct.new(content_encryption_key))
     token = enc.encrypt("", payload)
     output = enc.decrypt(token)
-    output.should == payload
+    expect(output).to eq(payload)
   end
 
   it "can encrypt and decrypt tokens with the RSA1_5 algorithm" do
@@ -19,7 +19,7 @@ shared_examples "algorithm compatibility" do |enc_class|
     token = encrypter.encrypt("", payload)
     decrypter = enc_class.new(Sandal::Enc::Alg::RSA1_5.new(rsa))
     output = decrypter.decrypt(token)
-    output.should == payload
+    expect(output).to eq(payload)
   end
 
   it "can encrypt and decrypt tokens with the RSA-OAEP algorithm" do
@@ -29,7 +29,7 @@ shared_examples "algorithm compatibility" do |enc_class|
     token = encrypter.encrypt("", payload)
     decrypter = enc_class.new(Sandal::Enc::Alg::RSA_OAEP.new(rsa))
     output = decrypter.decrypt(token)
-    output.should == payload
+    expect(output).to eq(payload)
   end
 
 end

--- a/spec/sandal/sig/es_spec.rb
+++ b/spec/sandal/sig/es_spec.rb
@@ -16,44 +16,44 @@ shared_examples "signing and validation" do |enc_class|
 
   it "can sign data and validate signatures" do
     data = "some data to sign"
-    group = OpenSSL::PKey::EC::Group.new(enc_class::CURVE_NAME) 
+    group = OpenSSL::PKey::EC::Group.new(enc_class::CURVE_NAME)
     private_key = OpenSSL::PKey::EC.new(group).generate_key
     signer = enc_class.new(private_key)
     signature = signer.sign(data)
     public_key = OpenSSL::PKey::EC.new(group)
     public_key.public_key = private_key.public_key
     validator = enc_class.new(public_key)
-    validator.valid?(signature, data).should == true
+    expect(validator.valid?(signature, data)).to eq(true)
   end
 
   it "can use DER-encoded keys to sign data and validate signatures" do
     data = "some data to sign"
-    group = OpenSSL::PKey::EC::Group.new(enc_class::CURVE_NAME) 
+    group = OpenSSL::PKey::EC::Group.new(enc_class::CURVE_NAME)
     private_key = OpenSSL::PKey::EC.new(group).generate_key
     signer = enc_class.new(private_key.to_der)
     signature = signer.sign(data)
     public_key = OpenSSL::PKey::EC.new(group)
     public_key.public_key = private_key.public_key
     validator = enc_class.new(public_key.to_der)
-    validator.valid?(signature, data).should == true
+    expect(validator.valid?(signature, data)).to eq(true)
   end
 
   it "can use PEM-encoded keys to sign data and validate signatures" do
     data = "some data to sign"
-    group = OpenSSL::PKey::EC::Group.new(enc_class::CURVE_NAME) 
+    group = OpenSSL::PKey::EC::Group.new(enc_class::CURVE_NAME)
     private_key = OpenSSL::PKey::EC.new(group).generate_key
     signer = enc_class.new(private_key.to_pem)
     signature = signer.sign(data)
     public_key = OpenSSL::PKey::EC.new(group)
     public_key.public_key = private_key.public_key
     validator = enc_class.new(public_key.to_pem)
-    validator.valid?(signature, data).should == true
+    expect(validator.valid?(signature, data)).to eq(true)
   end
 
   context "#initialize" do
 
     it "raises an argument error if the key has the wrong curve" do
-      group = OpenSSL::PKey::EC::Group.new("secp224k1") 
+      group = OpenSSL::PKey::EC::Group.new("secp224k1")
       private_key = OpenSSL::PKey::EC.new(group).generate_key
       expect { enc_class.new(private_key) }.to raise_error ArgumentError
     end
@@ -62,39 +62,39 @@ shared_examples "signing and validation" do |enc_class|
 
   context "#valid?" do
 
-    it "fails to validate the signature when the key is changed" do 
+    it "fails to validate the signature when the key is changed" do
       data = "some data to sign"
-      group = OpenSSL::PKey::EC::Group.new(enc_class::CURVE_NAME) 
+      group = OpenSSL::PKey::EC::Group.new(enc_class::CURVE_NAME)
       private_key = OpenSSL::PKey::EC.new(group).generate_key
       signer = enc_class.new(private_key)
       signature = signer.sign(data)
       public_key = OpenSSL::PKey::EC.new(group).generate_key
       validator = enc_class.new(public_key)
-      validator.valid?(signature, data).should == false
+      expect(validator.valid?(signature, data)).to eq(false)
     end
 
-    it "fails to validate the signature when the signature is changed" do 
+    it "fails to validate the signature when the signature is changed" do
       data = "some data to sign"
-      group = OpenSSL::PKey::EC::Group.new(enc_class::CURVE_NAME) 
+      group = OpenSSL::PKey::EC::Group.new(enc_class::CURVE_NAME)
       private_key = OpenSSL::PKey::EC.new(group).generate_key
       signer = enc_class.new(private_key)
       signature = signer.sign(data)
       public_key = OpenSSL::PKey::EC.new(group)
       public_key.public_key = private_key.public_key
       validator = enc_class.new(public_key)
-      validator.valid?(signature + "x", data).should == false
+      expect(validator.valid?(signature + "x", data)).to eq(false)
     end
 
-    it "fails to validate the signature when the data is changed" do 
+    it "fails to validate the signature when the data is changed" do
       data = "some data to sign"
-      group = OpenSSL::PKey::EC::Group.new(enc_class::CURVE_NAME) 
+      group = OpenSSL::PKey::EC::Group.new(enc_class::CURVE_NAME)
       private_key = OpenSSL::PKey::EC.new(group).generate_key
       signer = enc_class.new(private_key)
       signature = signer.sign(data)
       public_key = OpenSSL::PKey::EC.new(group)
       public_key.public_key = private_key.public_key
       validator = enc_class.new(public_key)
-      validator.valid?(signature, data + "x").should == false
+      expect(validator.valid?(signature, data + "x")).to eq(false)
     end
 
   end
@@ -110,7 +110,7 @@ describe Sandal::Sig::ES do
       s = make_bn([197, 10, 7, 211, 140, 60, 112, 229, 216, 241, 45, 175, 8, 74, 84, 128, 166, 101, 144, 197, 242, 147, 80, 154, 143, 63, 127, 138, 131, 163, 84, 213])
       signature = Sandal::Sig::ES.encode_jws_signature(r, s, 256)
       base64_signature = Sandal::Util.jwt_base64_encode(signature)
-      base64_signature.should == "DtEhU3ljbEg8L38VWAfUAqOyKAM6-Xx-F4GawxaepmXFCgfTjDxw5djxLa8ISlSApmWQxfKTUJqPP3-Kg6NU1Q"
+      expect(base64_signature).to eq("DtEhU3ljbEg8L38VWAfUAqOyKAM6-Xx-F4GawxaepmXFCgfTjDxw5djxLa8ISlSApmWQxfKTUJqPP3-Kg6NU1Q")
     end
 
     it "can encode the signature in JWS draft-11 appendix 4" do
@@ -118,7 +118,7 @@ describe Sandal::Sig::ES do
       s = make_bn([0, 111, 6, 105, 44, 5, 41, 208, 128, 61, 152, 40, 92, 61, 152, 4, 150, 66, 60, 69, 247, 196, 170, 81, 193, 199, 78, 59, 194, 169, 16, 124, 9, 143, 42, 142, 131, 48, 206, 238, 34, 175, 83, 203, 220, 159, 3, 107, 155, 22, 27, 73, 111, 68, 68, 21, 238, 144, 229, 232, 148, 188, 222, 59, 242, 103])
       signature = Sandal::Sig::ES.encode_jws_signature(r, s, 521)
       base64_signature = Sandal::Util.jwt_base64_encode(signature)
-      base64_signature.should == "AdwMgeerwtHoh-l192l60hp9wAHZFVJbLfD_UxMi70cwnZOYaRI1bKPWROc-mZZqwqT2SI-KGDKB34XO0aw_7XdtAG8GaSwFKdCAPZgoXD2YBJZCPEX3xKpRwcdOO8KpEHwJjyqOgzDO7iKvU8vcnwNrmxYbSW9ERBXukOXolLzeO_Jn"
+      expect(base64_signature).to eq("AdwMgeerwtHoh-l192l60hp9wAHZFVJbLfD_UxMi70cwnZOYaRI1bKPWROc-mZZqwqT2SI-KGDKB34XO0aw_7XdtAG8GaSwFKdCAPZgoXD2YBJZCPEX3xKpRwcdOO8KpEHwJjyqOgzDO7iKvU8vcnwNrmxYbSW9ERBXukOXolLzeO_Jn")
     end
 
   end
@@ -131,7 +131,7 @@ describe Sandal::Sig::ES256 do
   context "#name" do
     it "is 'ES256'" do
       enc = Sandal::Sig::ES256.new(OpenSSL::PKey::EC.new("prime256v1").generate_key)
-      enc.name.should == "ES256"
+      expect(enc.name).to eq("ES256")
     end
   end
 
@@ -144,11 +144,11 @@ describe Sandal::Sig::ES256 do
       data = "eyJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlfQ"
       signature = Sandal::Util.jwt_base64_decode("DtEhU3ljbEg8L38VWAfUAqOyKAM6-Xx-F4GawxaepmXFCgfTjDxw5djxLa8ISlSApmWQxfKTUJqPP3-Kg6NU1Q")
 
-      group = OpenSSL::PKey::EC::Group.new("prime256v1") 
+      group = OpenSSL::PKey::EC::Group.new("prime256v1")
       public_key = OpenSSL::PKey::EC.new(group)
       public_key.public_key = make_point(group, x, y)
       validator = Sandal::Sig::ES256.new(public_key)
-      validator.valid?(signature, data).should == true
+      expect(validator.valid?(signature, data)).to eq(true)
     end
 
   end
@@ -161,7 +161,7 @@ describe Sandal::Sig::ES384 do
   context "#name" do
     it "is 'ES384'" do
       enc = Sandal::Sig::ES384.new(OpenSSL::PKey::EC.new("secp384r1").generate_key)
-      enc.name.should == "ES384"
+      expect(enc.name).to eq("ES384")
     end
   end
 
@@ -173,7 +173,7 @@ describe Sandal::Sig::ES512 do
   context "#name" do
     it "is 'ES512'" do
       enc = Sandal::Sig::ES512.new(OpenSSL::PKey::EC.new("secp521r1").generate_key)
-      enc.name.should == "ES512"
+      expect(enc.name).to eq("ES512")
     end
   end
 
@@ -186,11 +186,11 @@ describe Sandal::Sig::ES512 do
       data = "eyJhbGciOiJFUzUxMiJ9.UGF5bG9hZA"
       signature = Sandal::Util.jwt_base64_decode("AdwMgeerwtHoh-l192l60hp9wAHZFVJbLfD_UxMi70cwnZOYaRI1bKPWROc-mZZqwqT2SI-KGDKB34XO0aw_7XdtAG8GaSwFKdCAPZgoXD2YBJZCPEX3xKpRwcdOO8KpEHwJjyqOgzDO7iKvU8vcnwNrmxYbSW9ERBXukOXolLzeO_Jn")
 
-      group = OpenSSL::PKey::EC::Group.new("secp521r1") 
+      group = OpenSSL::PKey::EC::Group.new("secp521r1")
       public_key = OpenSSL::PKey::EC.new(group)
       public_key.public_key = make_point(group, x, y)
       validator = Sandal::Sig::ES512.new(public_key)
-      validator.valid?(signature, data).should == true
+      expect(validator.valid?(signature, data)).to eq(true)
     end
 
   end

--- a/spec/sandal/sig/hs_spec.rb
+++ b/spec/sandal/sig/hs_spec.rb
@@ -8,7 +8,7 @@ shared_examples "signing and validation" do |enc_class|
     key = "A secret key"
     signer = enc_class.new(key)
     signature = signer.sign(data)
-    signer.valid?(signature, data).should == true
+    expect(signer.valid?(signature, data)).to eq(true)
   end
 
   context "#valid?" do
@@ -19,7 +19,7 @@ shared_examples "signing and validation" do |enc_class|
       signer = enc_class.new(key)
       signature = signer.sign(data)
       verifier = enc_class.new(key + "x")
-      verifier.valid?(signature, data).should == false
+      expect(verifier.valid?(signature, data)).to eq(false)
     end
 
     it "fails to validate the signature when the signature is changed" do
@@ -27,7 +27,7 @@ shared_examples "signing and validation" do |enc_class|
       key = "Another secret key"
       signer = enc_class.new(key)
       signature = signer.sign(data)
-      signer.valid?(signature + "x", data).should == false
+      expect(signer.valid?(signature + "x", data)).to eq(false)
     end
 
     it "fails to validate the signature when the data is changed" do
@@ -35,7 +35,7 @@ shared_examples "signing and validation" do |enc_class|
       key = "Another secret key"
       signer = enc_class.new(key)
       signature = signer.sign(data)
-      signer.valid?(signature, data + "x").should == false
+      expect(signer.valid?(signature, data + "x")).to eq(false)
     end
 
   end
@@ -48,7 +48,7 @@ describe Sandal::Sig::HS256 do
   context "#name" do
     it "is 'HS256'" do
       enc = Sandal::Sig::HS256.new("any old key")
-      enc.name.should == "HS256"
+      expect(enc.name).to eq("HS256")
     end
   end
 
@@ -57,7 +57,7 @@ describe Sandal::Sig::HS256 do
     key = [3, 35, 53, 75, 43, 15, 165, 188, 131, 126, 6, 101, 119, 123, 166, 143, 90, 179, 40, 230, 240, 84, 201, 40, 169, 15, 132, 178, 210, 80, 46, 191, 211, 251, 90, 146, 210, 6, 71, 239, 150, 138, 180, 195, 119, 98, 61, 34, 61, 46, 33, 114, 5, 46, 79, 8, 192, 205, 154, 245, 103, 208, 128, 163].pack("C*")
     signer = Sandal::Sig::HS256.new(key)
     signature = [116, 24, 223, 180, 151, 153, 224, 37, 79, 250, 96, 125, 216, 173, 187, 186, 22, 212, 37, 77, 105, 214, 191, 240, 91, 88, 5, 88, 83, 132, 141, 121].pack("C*") 
-    signer.valid?(signature, data).should == true
+    expect(signer.valid?(signature, data)).to eq(true)
   end
 
 end
@@ -68,7 +68,7 @@ describe Sandal::Sig::HS384 do
   context "#name" do
     it "is 'HS384'" do
       enc = Sandal::Sig::HS384.new("any old key")
-      enc.name.should == "HS384"
+      expect(enc.name).to eq("HS384")
     end
   end
 
@@ -80,7 +80,7 @@ describe Sandal::Sig::HS512 do
   context "#name" do
     it "is 'HS512'" do
       enc = Sandal::Sig::HS512.new("any old key")
-      enc.name.should == "HS512"
+      expect(enc.name).to eq("HS512")
     end
   end
   

--- a/spec/sandal/sig/rs_spec.rb
+++ b/spec/sandal/sig/rs_spec.rb
@@ -9,7 +9,7 @@ shared_examples "signing and validation" do |enc_class|
     signer = enc_class.new(private_key)
     signature = signer.sign(data)
     validator = enc_class.new(private_key.public_key)
-    validator.valid?(signature, data).should == true
+    expect(validator.valid?(signature, data)).to eq(true)
   end
 
   it "can use DER-encoded keys to sign data and validate signatures" do
@@ -18,7 +18,7 @@ shared_examples "signing and validation" do |enc_class|
     signer = enc_class.new(private_key.to_der)
     signature = signer.sign(data)
     validator = enc_class.new(private_key.public_key.to_der)
-    validator.valid?(signature, data).should == true
+    expect(validator.valid?(signature, data)).to eq(true)
   end
 
   it "can use PEM-encoded keys to sign data and validate signatures" do
@@ -27,7 +27,7 @@ shared_examples "signing and validation" do |enc_class|
     signer = enc_class.new(private_key.to_pem)
     signature = signer.sign(data)
     validator = enc_class.new(private_key.public_key.to_pem)
-    validator.valid?(signature, data).should == true
+    expect(validator.valid?(signature, data)).to eq(true)
   end
 
   context "#valid?" do
@@ -37,7 +37,7 @@ shared_examples "signing and validation" do |enc_class|
       signer = enc_class.new(OpenSSL::PKey::RSA.generate(2048))
       signature = signer.sign(data)
       validator = enc_class.new(OpenSSL::PKey::RSA.generate(2048).public_key)
-      validator.valid?(signature, data).should == false
+      expect(validator.valid?(signature, data)).to eq(false)
     end
 
     it "fails to validate the signature when the signature is changed" do
@@ -46,7 +46,7 @@ shared_examples "signing and validation" do |enc_class|
       signer = enc_class.new(private_key)
       signature = signer.sign(data)
       validator = enc_class.new(private_key.public_key)
-      validator.valid?(signature + "x", data).should == false
+      expect(validator.valid?(signature + "x", data)).to eq(false)
     end
 
     it "fails to validate the signature when the data is changed" do
@@ -55,7 +55,7 @@ shared_examples "signing and validation" do |enc_class|
       signer = enc_class.new(private_key)
       signature = signer.sign(data)
       validator = enc_class.new(private_key.public_key)
-      validator.valid?(signature, data + "x").should == false
+      expect(validator.valid?(signature, data + "x")).to eq(false)
     end
 
   end
@@ -72,13 +72,13 @@ describe Sandal::Sig::RS256 do
     signer = Sandal::Sig::RS384.new(private_key)
     signature = signer.sign(data)
     validator = Sandal::Sig::RS384.new(private_key.public_key)
-    validator.valid?(signature, data).should == true
+    expect(validator.valid?(signature, data)).to eq(true)
   end 
 
   context "#name" do
     it "is 'RS256'" do
       enc = Sandal::Sig::RS256.new(OpenSSL::PKey::RSA.generate(2048))
-      enc.name.should == "RS256"
+      expect(enc.name).to eq("RS256")
     end
   end
 
@@ -90,7 +90,7 @@ describe Sandal::Sig::RS384 do
   context "#name" do
     it "is 'RS384'" do
       enc = Sandal::Sig::RS384.new(OpenSSL::PKey::RSA.generate(2048))
-      enc.name.should == "RS384"
+      expect(enc.name).to eq("RS384")
     end
   end
 
@@ -102,7 +102,7 @@ describe Sandal::Sig::RS512 do
   context "#name" do
     it "is 'RS512'" do
       enc = Sandal::Sig::RS512.new(OpenSSL::PKey::RSA.generate(2048))
-      enc.name.should == "RS512"
+      expect(enc.name).to eq("RS512")
     end
   end
   

--- a/spec/sandal/util_spec.rb
+++ b/spec/sandal/util_spec.rb
@@ -9,7 +9,7 @@ describe Sandal::Util do
     it 'decodes base64 as per JWT example 6.1' do
       encoded = 'eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlfQ'
       val = Sandal::Util.jwt_base64_decode(encoded)
-      val.should == %!{"iss":"joe",\r\n "exp":1300819380,\r\n "http://example.com/is_root":true}!
+      expect(val).to eq(%!{"iss":"joe",\r\n "exp":1300819380,\r\n "http://example.com/is_root":true}!)
     end
 
     it 'raises an ArgumentError if base64 strings contain padding' do
@@ -27,7 +27,7 @@ describe Sandal::Util do
     it 'encodes base64 as per JWT example 6.1' do
       src =  %!{"iss":"joe",\r\n "exp":1300819380,\r\n "http://example.com/is_root":true}!
       encoded = Sandal::Util.jwt_base64_encode(src)
-      encoded.should == 'eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlfQ'
+      expect(encoded).to eq('eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlfQ')
     end
 
   end
@@ -35,31 +35,31 @@ describe Sandal::Util do
   context '#jwt_strings_equal?' do
 
     it 'compares nil strings as equal' do
-      Sandal::Util.jwt_strings_equal?(nil, nil).should == true
+      expect(Sandal::Util.jwt_strings_equal?(nil, nil)).to eq(true)
     end
 
     it 'compares empty strings as equal' do
-      Sandal::Util.jwt_strings_equal?('', '').should == true
+      expect(Sandal::Util.jwt_strings_equal?('', '')).to eq(true)
     end
 
     it 'compares nil strings as unequal to empty strings' do
-      Sandal::Util.jwt_strings_equal?(nil, '').should == false
-      Sandal::Util.jwt_strings_equal?('', nil).should == false
+      expect(Sandal::Util.jwt_strings_equal?(nil, '')).to eq(false)
+      expect(Sandal::Util.jwt_strings_equal?('', nil)).to eq(false)
     end
 
     it 'compares equal strings as equal' do
-      Sandal::Util.jwt_strings_equal?('hello', 'hello').should == true
-      Sandal::Util.jwt_strings_equal?('a longer string', 'a longer string').should == true
+      expect(Sandal::Util.jwt_strings_equal?('hello', 'hello')).to eq(true)
+      expect(Sandal::Util.jwt_strings_equal?('a longer string', 'a longer string')).to eq(true)
     end
 
     it 'compares unequal strings as unequal' do
-      Sandal::Util.jwt_strings_equal?('hello', 'world').should == false
-      Sandal::Util.jwt_strings_equal?('a longer string', 'a different longer string').should == false
+      expect(Sandal::Util.jwt_strings_equal?('hello', 'world')).to eq(false)
+      expect(Sandal::Util.jwt_strings_equal?('a longer string', 'a different longer string')).to eq(false)
     end
 
     it 'compares strings without short-circuiting', :timing_dependent do
       measure_equals = -> a, b do
-        Benchmark.realtime { 100.times { Sandal::Util.jwt_strings_equal?(a, b) } } 
+        Benchmark.realtime { 100.times { Sandal::Util.jwt_strings_equal?(a, b) } }
       end
       ref = 'a' * 10000
       cmp1 = ('a' * 9999) + 'b'
@@ -67,7 +67,7 @@ describe Sandal::Util do
       t1 = measure_equals.(ref, cmp1)
       t2 = measure_equals.(ref, cmp2)
       range = (t1 - t1/20.0)..(t1 + t1/20.0)
-      range.should === t2
+      expect(range).to be === t2
     end
 
   end


### PR DESCRIPTION
Ran transpec to convert specs to 'expect' syntax used in RSpec 3.0.x.  After conversion everything runs green.
