### PR TITLE
Make MultiJson optional

### DIFF
--- a/lib/sandal/json.rb
+++ b/lib/sandal/json.rb
@@ -1,0 +1,43 @@
+module Sandal
+  # Contains JSON encode and decode functionality.
+  module Json
+    if !defined?(MultiJson)
+      require 'json'
+
+      # Decode a JSON string into Ruby.  This version delegates to the included JSON engine.
+      #
+      # @param encoded [String] The JSON string representation of the object.
+      # @return The decoded Ruby object.
+      def self.load(encoded)
+        JSON.parse(encoded)
+      end
+
+      # Encodes a Ruby object as JSON.  This version delegates to the included JSON engine.
+      #
+      # @param raw The Ruby object to be encoded
+      # @return [String] The JSON string representation of the object.
+      def self.dump(raw)
+        JSON.generate(raw)
+      end
+
+    else
+      require 'multi_json'
+
+      # Decode a JSON string into Ruby.  This version delegates to MultiJson.
+      #
+      # @param encoded [String] The JSON string representation of the object.
+      # @return The decoded Ruby object.
+      def self.load(encoded)
+        MultiJson.load(encoded)
+      end
+
+      # Encodes a Ruby object as JSON.  This version delegates to MultiJson.
+      #
+      # @param raw The Ruby object to be encoded
+      # @return [String] The JSON string representation of the object.
+      def self.dump(raw)
+        MultiJson.dump(raw)
+      end
+    end
+  end
+end

--- a/sandal.gemspec
+++ b/sandal.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.extra_rdoc_files = ["README.md", "LICENSE.md", "CHANGELOG.md"]
 
-  s.add_runtime_dependency "multi_json", "~> 1.7"
   s.add_runtime_dependency "jruby-openssl", "~> 0.7", ">= 0.7.3" if RUBY_PLATFORM == "java"
 
   s.add_development_dependency "bundler", ">= 1.3"

--- a/spec/sandal_spec.rb
+++ b/spec/sandal_spec.rb
@@ -1,6 +1,5 @@
 require 'helper'
 require 'openssl'
-require 'multi_json'
 
 describe Sandal do
 


### PR DESCRIPTION
MultiJson is being EOL'd and major libraries (Rails, uglifier, etc.) have started phasing out their dependency - https://github.com/rails/rails/pull/10576 . This PR accommodates this trend, by making MultiJson an optional dependency.

Users of the sandal gem can still use MultiJson by simply calling require 'multi_json' before they require the gem.
